### PR TITLE
rework(is_,same_as_)

### DIFF
--- a/include/type_var.hpp
+++ b/include/type_var.hpp
@@ -64,8 +64,8 @@ class var_impl {
   // simple helper to retrive the index from the type list
   template <typename T>
   using index_helper = te::eval_pipe_<
-      te::input_<Ts...>, te::zip_index, te::filter_<te::second, te::is_<T>>,
-      te::cond_<not_<te::is_<>>, te::first, te::input_<te::i<-1>>>>;
+      te::input_<Ts...>, te::zip_index, te::filter_<te::second, te::same_as_<T>>,
+      te::cond_<not_<te::same_as_<>>, te::first, te::input_<te::i<-1>>>>;
   //
   template <typename T>
   var_impl(T&& value) : m_index(index_helper<T>::value), m_storage{} {
@@ -116,7 +116,7 @@ class var_impl {
   template <typename T>
   constexpr inline bool is() const noexcept {
     return m_index == te::eval_pipe_<te::input_<Ts...>,
-                                     te::find_if_<te::is_<T>>, first>::value;
+                                     te::find_if_<te::same_as_<T>>, first>::value;
   }
 
   // STATIC ASSERTION
@@ -129,7 +129,7 @@ class var_impl {
                      te::none_of_<te::lift_<std::is_reference>>>::value,
       "No reference accepted");
   static_assert(
-      te::eval_pipe_<te::input_<Ts...>, te::none_of_<te::is_<void>>>::value,
+      te::eval_pipe_<te::input_<Ts...>, te::none_of_<te::same_as_<void>>>::value,
       "No reference accepted");
 };
 

--- a/test/type_expr.cpp
+++ b/test/type_expr.cpp
@@ -4,6 +4,7 @@
 //        http://www.boost.org/LICENSE_1_0.txt)
 
 #include "type_expr.hpp"
+
 #include <assert.h>
 
 #include <type_traits>
@@ -43,20 +44,21 @@ int main() {
   // UNWRAP TESTING
   // There was a problem with unwrap...
   // those test stay there because I don't want to debug this again.
-  te::eval_pipe_<input_<std::array<int,5>>, unwrap>{} = input_<int,i<5>>{};
-  te::eval_pipe_<input_<std::integer_sequence<int,5,6>>, unwrap>{} = input_<i<5>,i<6>>{};
+  te::eval_pipe_<input_<std::array<int, 5>>, unwrap>{} = input_<int, i<5>>{};
+  te::eval_pipe_<input_<std::integer_sequence<int, 5, 6>>, unwrap>{} =
+      input_<i<5>, i<6>>{};
   te::eval_pipe_<input_<ls_<int, i<0>>>, unwrap, second> t11 = i<0>{};
-  te::eval_pipe_<input_<ls_<int, i<0>>>, unwrap, pipe_<identity, second>> t12 =
+  te::eval_pipe_<input_<ls_<int, i<0>>>, unwrap, pipe_<identity, second>>{} =
       i<0>{};
-  te::eval_pipe_<input_<ls_<int, i<0>>>, unwrap, pipe_<second>> t13 = i<0>{};
-  te::eval_pipe_<input_<ls_<int, i<0>>>, pipe_<unwrap, pipe_<second>>> t14 =
+  te::eval_pipe_<input_<ls_<int, i<0>>>, unwrap, pipe_<second>>{} = i<0>{};
+  te::eval_pipe_<input_<ls_<int, i<0>>>, pipe_<unwrap, pipe_<second>>>{} =
       i<0>{};
 
-  te::eval_pipe_<input_<ls_<int, i<0>>>, pipe_<unwrap, first>, is_<int>> t15 =
-      b<true>{};
+  te::eval_pipe_<input_<ls_<int, i<0>>>, pipe_<unwrap, first>,
+                 same_as_<int>>{} = b<true>{};
 
-  constexpr te::eval_pipe_<input_<int>, unwrap> t =
-      type_expr::error_<te::unspecialized,int>{};
+  constexpr te::eval_pipe_<input_<int>, unwrap> unwrap_error =
+      type_expr::error_<te::unspecialized, int>{};
   // Once an error_<Ts...> is discover, the pipe continue but doesn't evaluate.
   // a catch_ metafunction will never be implemented.
 
@@ -65,7 +67,7 @@ int main() {
       pipe_unwrap2 = 0;
   constexpr te::eval_pipe_<input_<ls_<int>>, pipe_<unwrap>> pipe_unwrap3 = 0;
   constexpr te::eval_pipe_<input_<ls_<int, float>>, pipe_<unwrap>,
-                           is_<int, float>>
+                           same_as_<int, float>>
       pipe_unwrap4 = b<true>{};
   constexpr te::eval_pipe_<input_<ls_<int, float>>, pipe_<unwrap>, get_<0>>
       pipe_unwrap5 = 0;
@@ -76,12 +78,12 @@ int main() {
 
   // Calculation tests
   // -------------------------------------------------------------------
-  static_assert(te::eval_pipe_<input_<double>, plus_<int>, is_<double>>::value,
-                "");
-  static_assert(te::eval_pipe_<input_<i<21>, i<49>>, gcd, is_<i<7>>>::value,
-                "");
-  static_assert(te::eval_pipe_<input_<i<21>, i<49>>, lcm, is_<i<147>>>::value,
-                "");
+  static_assert(
+      te::eval_pipe_<input_<double>, plus_<int>, same_as_<double>>::value, "");
+  static_assert(
+      te::eval_pipe_<input_<i<21>, i<49>>, gcd, same_as_<i<7>>>::value, "");
+  static_assert(
+      te::eval_pipe_<input_<i<21>, i<49>>, lcm, same_as_<i<147>>>::value, "");
   // -------------------------------------------------------------------
 
   auto pipe_less_ = te::eval_pipe_<input_<i<1>, i<2>>, less_<>>{};
@@ -90,163 +92,172 @@ int main() {
   static_assert(pipe_less_.value, "");
   static_assert(pipe_less__2.value, "");
 
-  auto pipe_is_test = te::eval_pipe_<input_<i<1>>, is_<i<1>>>{};
+  auto pipe_is_test = te::eval_pipe_<input_<i<1>>, same_as_<i<1>>>{};
   static_assert(pipe_is_test.value, "");
 
   auto pipe_is_test_multi =
-      te::eval_pipe_<input_<i<1>, i<2>>, is_<i<1>, i<2>>>{};
+      te::eval_pipe_<input_<i<1>, i<2>>, same_as_<i<1>, i<2>>>{};
   static_assert(pipe_is_test_multi.value, "");
   // This is such a good feature; instead of always listify then compare with
   // ls_<...>
 
-  auto pipe_isnt_ = te::eval_pipe_<input_<i<1>, i<2>>, isnt_<int>>{};
+  auto pipe_isnt_ = te::eval_pipe_<input_<i<1>, i<2>>, not_same_as_<int>>{};
   static_assert(pipe_isnt_.value, "");
   // Isnt_ is the opposite of is_
 
-  auto pipe_add =
-      te::eval_pipe_<input_<int>, pipe_<push_back_<float>>, is_<int, float>>{};
+  auto pipe_add = te::eval_pipe_<input_<int>, pipe_<push_back_<float>>,
+                                 same_as_<int, float>>{};
   static_assert(pipe_add.value, "");
 
   auto pipe_add2 = te::eval_pipe_<input_<int, short>, pipe_<push_back_<float>>,
-                                  is_<int, short, float>>{};
+                                  same_as_<int, short, float>>{};
   static_assert(pipe_add2.value, "");
 
   static_assert(te::eval_pipe_<input_<int, float>, push_back_<ls_<>>,
-                               is_<int, float, ls_<>>>::value,
+                               same_as_<int, float, ls_<>>>::value,
                 "");
   static_assert(te::eval_pipe_<input_<int, float>, push_front_<ls_<>>,
-                               is_<ls_<>, int, float>>::value,
+                               same_as_<ls_<>, int, float>>::value,
                 "");
-  static_assert(te::eval_pipe_<push_back_<int>, is_<int>>::value, "");
+  static_assert(te::eval_pipe_<push_back_<int>, same_as_<int>>::value, "");
   // pushing types has never been this easy
 
-  static_assert(te::eval_pipe_<input_<int, int, int>, length, is_<i<3>>>::value,
-                "");
+  static_assert(
+      te::eval_pipe_<input_<int, int, int>, length, same_as_<i<3>>>::value, "");
   // length continue with the number of elements in the inputs inside a i<>
 
-  static_assert(te::eval_pipe_<input_<char>, size, is_<i<1>>>::value, "");
+  static_assert(te::eval_pipe_<input_<char>, size, same_as_<i<1>>>::value, "");
   static_assert(te::eval_pipe_<input_<char, char>, transform_<size>,
-                               is_<i<1>, i<1>>>::value,
+                               same_as_<i<1>, i<1>>>::value,
                 "");
   // size continue with the size of the type in the inputs inside a i<>
 
   static_assert(
-      te::eval_pipe_<input_<int, float, ls_<int>>, first, is_<int>>::value, "");
-  static_assert(
-      te::eval_pipe_<input_<int, float, ls_<int>>, last, is_<ls_<int>>>::value,
+      te::eval_pipe_<input_<int, float, ls_<int>>, first, same_as_<int>>::value,
       "");
+  static_assert(te::eval_pipe_<input_<int, float, ls_<int>>, last,
+                               same_as_<ls_<int>>>::value,
+                "");
   // Getting the first and the last.
 
   static_assert(te::eval_pipe_<input_<int, input_<int>, ls_<int, int>>, flatten,
-                               is_<int, int, ls_<int, int>>>::value,
+                               same_as_<int, int, ls_<int, int>>>::value,
                 "");
   // Flatten and join_list might be reworked
 
-  static_assert(
-      te::eval_pipe_<
-          input_<int, int, int>,
-          cond_<is_<int, int>, input_<b<false>>, is_<int, int, int>>>::value,
-      "");
+  static_assert(te::eval_pipe_<input_<int, int, int>,
+                               cond_<same_as_<int, int>, input_<b<false>>,
+                                     same_as_<int, int, int>>>::value,
+                "");
   // Conditional have a predicate and continue with the second or the third
   // function
 
-  static_assert(
-      te::eval_pipe_<input_<int, float, short>, get_<1>, is_<float>>::value,
-      "");
+  static_assert(te::eval_pipe_<input_<int, float, short>, get_<1>,
+                               same_as_<float>>::value,
+                "");
   static_assert(te::eval_pipe_<input_<i<1>, i<2>>, transform_<plus_<i<3>>>,
-                               is_<i<4>, i<5>>>::value,
+                               same_as_<i<4>, i<5>>>::value,
                 "");
   // Transform apply this metafunctor to the types one by one
   // Can also be called a map_ but I disgress transform_ is a better name
 
   static_assert(te::eval_pipe_<input_<i<1>>, fork_<plus_<i<1>>, plus_<i<2>>>,
-                               is_<i<2>, i<3>>>::value,
+                               same_as_<i<2>, i<3>>>::value,
                 "");
   // pipes and forks in a single expression ? Cool Stuff
 
-  static_assert(te::eval_pipe_<input_<int, float, short>, partition_<is_<int>>,
-                               is_<ls_<int>, ls_<float, short>>>::value,
-                "");
+  static_assert(
+      te::eval_pipe_<input_<int, float, short>, partition_<same_as_<int>>,
+                     same_as_<ls_<int>, ls_<float, short>>>::value,
+      "");
   // Partition , like the std counterpart, result in two
   // containers : first one with predicate == true,
   //              second one with predicate == false
-  
-  static_assert(te::eval_pipe_<te::input_<int,te::input_<float,float>,char>
-                , te::each_<te::is_<int>,te::is_<float,float>,te::is_<char>>
-                , te::all_of_<te::is_<std::true_type>>
-                >::value,"");
+
+  static_assert(
+      te::eval_pipe_<te::input_<int, te::input_<float, float>, char>,
+                     te::each_<te::same_as_<int>, te::same_as_<float, float>,
+                               te::same_as_<char>>,
+                     te::all_of_<te::same_as_<std::true_type>>>::value,
+      "");
   // Each isn't my favorite fonction, but is there nonetheless.
   //
 
   static_assert(te::eval_pipe_<input_<int, float, int, short>,
-                               replace_if_<is_<int>, input_<float>>,
-                               is_<float, float, float, short>>::value,
+                               replace_if_<same_as_<int>, input_<float>>,
+                               same_as_<float, float, float, short>>::value,
                 "");
   // replace_if transform the type into another if the predicate is true
 
-  static_assert(
-      te::eval_pipe_<input_<input_<int, short>, input_<float, char>>, cartesian,
-                     is_<input_<int, float>, input_<int, char>,
-                         input_<short, float>, input_<short, char>>>::value,
-      "");
+  static_assert(te::eval_pipe_<
+                    input_<input_<int, short>, input_<float, char>>, cartesian,
+                    same_as_<input_<int, float>, input_<int, char>,
+                             input_<short, float>, input_<short, char>>>::value,
+                "");
   // cartesian is a little bit special : given two lists, it return each
   // permutation possible while respecting the order
 
-  static_assert(te::eval_pipe_<input_<i<1>, i<2>, i<3>, i<4>, i<5>>,
-                               any_of_<is_<i<5>>>, is_<std::true_type>>::value,
-                "");
-  static_assert(te::eval_pipe_<input_<i<1>, i<0>, i<0>>, count_if_<is_<i<0>>>,
-                               is_<i<2>>>::value,
-                "");
+  static_assert(
+      te::eval_pipe_<input_<i<1>, i<2>, i<3>, i<4>, i<5>>,
+                     any_of_<same_as_<i<5>>>, same_as_<std::true_type>>::value,
+      "");
+  static_assert(
+      te::eval_pipe_<input_<i<1>, i<0>, i<0>>, count_if_<same_as_<i<0>>>,
+                     same_as_<i<2>>>::value,
+      "");
   // Count_if does exactly what is name suggest.
 
-  static_assert(te::eval_pipe_<input_<int, int, int>, all_of_<is_<int>>>::value,
-                "");
   static_assert(
-      te::eval_pipe_<input_<int, float, int>, any_of_<is_<float>>>::value, "");
+      te::eval_pipe_<input_<int, int, int>, all_of_<same_as_<int>>>::value, "");
   static_assert(
-      te::eval_pipe_<input_<int, float, int>, none_of_<is_<char>>>::value, "");
+      te::eval_pipe_<input_<int, float, int>, any_of_<same_as_<float>>>::value,
+      "");
+  static_assert(
+      te::eval_pipe_<input_<int, float, int>, none_of_<same_as_<char>>>::value,
+      "");
   // Does exactly the same as their std:: counterpart
 
-  static_assert(
-      te::eval_pipe_<input_<int, int, int>, pipe_<get_<0>>, is_<int>>::value,
-      "");
-  constexpr te::eval_pipe_<input_<i<1>, i<2>, i<3>>, get_<-1>, is_<>> t_err =
-      type_expr::error_<type_expr::get_<-1>::index_out_of_range>{};
-  constexpr te::eval_pipe_<input_<int, int, int>, pipe_<get_<3>>, is_<>>
+  static_assert(te::eval_pipe_<input_<int, int, int>, pipe_<get_<0>>,
+                               same_as_<int>>::value,
+                "");
+  constexpr te::eval_pipe_<input_<i<1>, i<2>, i<3>>, get_<-1>, same_as_<>>
+      t_err = type_expr::error_<type_expr::get_<-1>::index_out_of_range>{};
+  constexpr te::eval_pipe_<input_<int, int, int>, pipe_<get_<3>>, same_as_<>>
       t_err2 = type_expr::error_<type_expr::get_<3>::index_out_of_range>{};
 
-  static_assert(te::eval_pipe_<input_<i<2>>, mkseq, is_<i<0>, i<1>>>::value,
-                "");
-  static_assert(te::eval_pipe_<input_<i<1>>, mkseq, is_<i<0>>>::value, "");
-  static_assert(te::eval_pipe_<input_<i<0>>, mkseq, is_<>>::value, "");
+  static_assert(
+      te::eval_pipe_<input_<i<2>>, mkseq, same_as_<i<0>, i<1>>>::value, "");
+  static_assert(te::eval_pipe_<input_<i<1>>, mkseq, same_as_<i<0>>>::value, "");
+  static_assert(te::eval_pipe_<input_<i<0>>, mkseq, same_as_<>>::value, "");
 
   static_assert(
       te::eval_pipe_<input_<int, i<0>>,
-                     cond_<pipe_<first, is_<int>>, input_<std::true_type>,
+                     cond_<pipe_<first, same_as_<int>>, input_<std::true_type>,
                            input_<std::false_type>>>::value,
       "");
-  static_assert(te::eval_pipe_<input_<float, int, float, int>,
-                               find_if_<is_<int>>, is_<i<1>, int>>::value,
-                "");
+  static_assert(
+      te::eval_pipe_<input_<float, int, float, int>, find_if_<same_as_<int>>,
+                     same_as_<i<1>, int>>::value,
+      "");
   static_assert(
       te::eval_pipe_<input_<int, float>, zip_index,
-                     is_<input_<i<0>, int>, input_<i<1>, float>>>::value,
+                     same_as_<input_<i<0>, int>, input_<i<1>, float>>>::value,
       "");
-  static_assert(
-      te::eval_pipe_<input_<i<1>>, plus_<i<1>>, mkseq, is_<i<0>, i<1>>>::value,
-      "");
+  static_assert(te::eval_pipe_<input_<i<1>>, plus_<i<1>>, mkseq,
+                               same_as_<i<0>, i<1>>>::value,
+                "");
 
   // We will use te::ls_<...> instead of tuple but for the purpose of this test
   // the same result is achieve
   static_assert(
-      te::eval_pipe_<te::input_<te::ls_<int, float, char>, te::ls_<>,
-                                te::ls_<int*, char*>, te::ls_<int>>,
-                     te::transform_<te::unwrap, te::length, te::mkseq>,
-                     te::zip_index, transform_<te::cartesian>, flatten, unzip,
-                     transform_<quote_std_integer_sequence>,
-                     is_<std::integer_sequence<int, 0, 0, 0, 2, 2, 3>,
-                         std::integer_sequence<int, 0, 1, 2, 0, 1, 0>>>::value,
+      te::eval_pipe_<
+          te::input_<te::ls_<int, float, char>, te::ls_<>, te::ls_<int*, char*>,
+                     te::ls_<int>>,
+          te::transform_<te::unwrap, te::length, te::mkseq>, te::zip_index,
+          transform_<te::cartesian>, flatten, unzip,
+          transform_<quote_std_integer_sequence>,
+          same_as_<std::integer_sequence<int, 0, 0, 0, 2, 2, 3>,
+                   std::integer_sequence<int, 0, 1, 2, 0, 1, 0>>>::value,
       "Eric Niebler Challenge");
 
   // On this challenge, the goal was to unwrap, remove empty class, sort them by
@@ -254,27 +265,24 @@ int main() {
   // signature of the type accept only types.
   struct Z {};  // EMPTY
 
-  using ArthurODwyer_metafunction = te::on_args_<te::remove_if_<te::lift_<std::is_empty>>,
-                       te::sort_<te::transform_<te::size>, te::greater_<>>>;
+  using ArthurODwyer_metafunction =
+      te::on_args_<te::remove_if_<te::lift_<std::is_empty>>,
+                   te::sort_<te::transform_<te::size>, te::greater_<>>>;
 
   static_assert(
       te::eval_pipe_<
           te::input_<te::ls_<Z, int[4], Z, int[1], Z, int[2], int[3]>>,
           ArthurODwyer_metafunction,
-          is_<te::ls_<int[4], int[3], int[2], int[1]>>>::value,
+          same_as_<te::ls_<int[4], int[3], int[2], int[1]>>>::value,
       "Arthur O'Dwyer");
 
-  static_assert(
-      te::eval_pipe_<
-          te::input_<
-            te::ls_<Z, int[4], Z, int[1], Z, int[2], int[3]>,
-            te::ls_<int[2], Z, int[1], Z, int[3]>
-          >,
-          te::transform_< ArthurODwyer_metafunction>,
-          is_<te::ls_<int[4], int[3], int[2], int[1]>
-                ,te::ls_<int[3],int[2],int[1]>>>::value,
-      "Arthur O'Dwyer but with multiple types");
-
+  static_assert(te::eval_pipe_<
+                    te::input_<te::ls_<Z, int[4], Z, int[1], Z, int[2], int[3]>,
+                               te::ls_<int[2], Z, int[1], Z, int[3]>>,
+                    te::transform_<ArthurODwyer_metafunction>,
+                    same_as_<te::ls_<int[4], int[3], int[2], int[1]>,
+                             te::ls_<int[3], int[2], int[1]>>>::value,
+                "Arthur O'Dwyer but with multiple types");
 
   static_assert(
       te::eval_pipe_<
@@ -283,6 +291,6 @@ int main() {
                     te::sort_<te::greater_<>, te::not_<>>>,
           te::lift_<std::is_same>>::value,
       "");
-  
+
   return 0;
 }


### PR DESCRIPTION
is_ will be reused for something else.
It's a breaking change but a welcome one.
