### PR TITLE
Tup fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(type_expr INTERFACE
 # Testing type_expr
 option( TYPE_EXPR_TEST 
         "Type_expr testing with CTest" 
-        OFF)
+        ON)
 include(CTest)
 add_subdirectory(test)
 

--- a/include/type_expr.hpp
+++ b/include/type_expr.hpp
@@ -854,6 +854,9 @@ struct remove_if_
 template <typename... UnaryPredicate>
 struct filter_ : remove_if_<not_<UnaryPredicate...>> {};
 
+//KEEP_IF_ : Same as filter_ but with better name
+template<typename ... UnaryPredicate>
+struct keep_if_ : remove_if_<UnaryPredicate..., not_<>>{};
 
 // PARTITION_ : Continue with two list. First predicate is true, Second
 // predicate is false

--- a/include/type_expr.hpp
+++ b/include/type_expr.hpp
@@ -1274,45 +1274,6 @@ struct lcm {
 // note : it's implicit that you receive two types, so you probably need to
 // transform them. eg : sort by size : sort_<transform_<size>, greater_<> >
 
-
-template <typename... BinaryPredicate>
-struct sort2_ {
-	template <typename A, typename B>
-	struct eager {
-  		typedef ts_<> type;
-	};
-
-	template <typename A>
-	struct eager<A, std::true_type> {
-  		typedef ts_<A> type;
-	};
-
-	template <typename... L>
-	struct sort_impl;
-	template <typename T>
-	struct sort_impl<T> {
-    	typedef T type;
-	};
-
-	template <typename... Ts, typename F>
-	struct sort_impl<ts_<F, Ts...>> {
-    	typedef typename sort_impl<typename flatten::template f<
-        	ts_<>,
-        	typename eager<Ts, typename pipe_<BinaryPredicate...>::template f<
-            	Ts, F>::type>::type...>::type>::type Yes_types;
-    	typedef typename sort_impl<typename flatten::template f<
-        	ts_<>,
-        	typename eager<Ts, typename not_<pipe_<BinaryPredicate...>>::template f<
-            	Ts, F>::type>::type...>::type>::type No_types;
-
-    	typedef typename flatten::template f<ts_<>, Yes_types, F, No_types>::type type;
-	};
-	template <typename... Ts>
-	struct f {
-    	typedef typename sort_impl<ts_<Ts...>>::type type;
-	};
-};
-
 template<typename ... BP>
 struct sort_
 {

--- a/include/type_expr.hpp
+++ b/include/type_expr.hpp
@@ -846,7 +846,7 @@ struct remove_if_
 	template<typename ... Ts>
 	struct f {
 		template<typename T> using Expr = typename std::conditional<eval_pipe_<input_<T>,Up...>::value,identity,input_append_<T>>::type;
-		using type = eval_pipe_<Expr<Ts>...> ;//pipe_<cond_<pipe_<Up...>,input_<identity>,wrap_<input_append_>>::template f<Ts>::type...>;
+		using type = eval_pipe_<Expr<Ts>...> ;
 	};
 };
 

--- a/include/type_tup.hpp
+++ b/include/type_tup.hpp
@@ -82,7 +82,7 @@ namespace te {
   				auto get() -> te::eval_pipe_<te::ts_<te::ls_<Is,Ts>...>,te::filter_<te::unwrap,te::first,te::same_as_<te::i<I>>>,te::unwrap,te::second> & {
 					return te::eval_pipe_<te::ts_<te::ls_<Is,Ts>...>,te::filter_<te::unwrap,te::first,te::same_as_<i<I>>>,te::unwrap,te::wrap_<tup_element>>::data;
   				}
-	template<typename T, std::size_t I = 0>
+			template<typename T, int I = 0>
   				auto get() -> T&
   				{
   					return 
@@ -91,9 +91,7 @@ namespace te {
 						, te::at_c<I>
 					    >::data;
   				}
-	
-
-	};
+		};
 
 	// TUP
 
@@ -105,7 +103,6 @@ namespace te {
 
 	template <typename... Ts>
 		struct tup : te_tup_metafunction<Ts...> {
-			//using te_tup_metafunction<Ts...>::tup_impl;
 			static constexpr std::size_t size = sizeof...(Ts);
 
 			~tup() = default;
@@ -119,7 +116,7 @@ namespace te {
 			tup(const te::tup<Ts...>& o) : te_tup_metafunction<Ts...>{(te_tup_metafunction<Ts...>)o} {}
 			tup(te::tup<Ts...>&& o) : te_tup_metafunction<Ts...>{std::forward<te_tup_metafunction<Ts...>>(o)} {}
 
-  				};
+  		};
 
 	template <class T>
 		struct unwrap_refwrapper{using type = T;};

--- a/include/type_tup.hpp
+++ b/include/type_tup.hpp
@@ -13,150 +13,150 @@
 
 namespace te {
 
-// FORWARD DECLARATION
+	// FORWARD DECLARATION
 
-// TUP_INST
-template <typename Index, typename Type>
-struct tup_inst;
+	// TUP_INST
+	template <typename Index, typename Type>
+		struct tup_inst;
 
-// TUP_IMPL
-template <typename... Zip_Indexes_Types>
-struct tup_impl;
+	// TUP_IMPL
+	template <typename... Zip_Indexes_Types>
+		struct tup_impl;
 
-// TUP
-template <typename... Ts>
-struct tup;
+	// TUP
+	template <typename... Ts>
+		struct tup;
 
-// IMPLEMENTATION
+	// IMPLEMENTATION
 
-// TUP_INST
-template <int I, typename T>
-struct tup_inst<te::i<I>, T> {
-	  tup_inst() : data{}{} 
-	  tup_inst(const T& t) : data{t} {} // Ref
-	  template<typename U>
-	  tup_inst(U &&t) : data(std::forward<U>(t)) {} // Move or copy
-  	~tup_inst() = default;
+	// TUP_INST
+	template <int I, typename T>
+		struct tup_inst<te::i<I>, T> {
+	  		tup_inst() : data{}{} 
+	  		tup_inst(const T& t) : data{t} {} // Ref
+	  		template<typename U>
+	  			tup_inst(U &&t) : data(std::forward<U>(t)) {} // Move or copy
+  			~tup_inst() = default;
 
- //protected:
-  T data;
-};
+ 			//protected:
+  			T data;
+		};
 
-// TUP_IMPL
-template <typename... Is, typename... Ts, template <typename...> class TypeList>
-struct tup_impl<TypeList<Is, Ts>...> : tup_inst<Is, Ts>... {
-	tup_impl() : tup_inst<Is,Ts>{}...{}
-  tup_impl(const Ts& ... ts) : tup_inst<Is, Ts>(ts)... {}
-  template<typename ... Us>
-  tup_impl(Us &&... ts) : tup_inst<Is, Ts>(std::forward<Us>(ts))... {}
-  ~tup_impl() = default;
-  template <unsigned int I>
-  auto get() -> te::eval_pipe_<ts_<Ts...>, te::at_c<I>> & {
-    return te::eval_pipe_<ts_<tup_inst<Is, Ts>...>, te::at_c<I>>::data;
-  }
-};
+	// TUP_IMPL
+	template <typename... Is, typename... Ts, template <typename...> class TypeList>
+		struct tup_impl<TypeList<Is, Ts>...> : tup_inst<Is, Ts>... {
+			tup_impl() : tup_inst<Is,Ts>{}...{}
+  			tup_impl(const Ts& ... ts) : tup_inst<Is, Ts>(ts)... {}
+  			template<typename ... Us>
+  				tup_impl(Us &&... ts) : tup_inst<Is, Ts>(std::forward<Us>(ts))... {}
+  			~tup_impl() = default;
+  			template <unsigned int I>
+  				auto get() -> te::eval_pipe_<ts_<Ts...>, te::at_c<I>> & {
+    				return te::eval_pipe_<ts_<tup_inst<Is, Ts>...>, te::at_c<I>>::data;
+  				}
+		};
 
-// TUP
-template <typename... Ts>
-using te_tup_metafunction =
-    te::eval_pipe_<te::ts_<Ts...>, te::zip_index, te::wrap_<tup_impl>>;
+	// TUP
+	template <typename... Ts>
+		using te_tup_metafunction =
+    	te::eval_pipe_<te::ts_<Ts...>, te::zip_index, te::wrap_<tup_impl>>;
 
-template <typename... Ts>
-struct tup : te_tup_metafunction<Ts...> {
-  //tup(): te_tup_metafunction<Ts...>{}{}
-	tup() : te::te_tup_metafunction<Ts...>{}{
-		static_assert(te::eval_pipe_<te::ts_<Ts...>,te::all_of_<te::trait_<std::is_default_constructible>>>::value,"Type is not default constructible");
-	}
-  tup(const Ts& ... ts) : te_tup_metafunction<Ts...>(ts...) {}
-  template<typename ... Us>
-  tup(Us &&... ts) : te_tup_metafunction<Ts...>(std::forward<Us>(ts)...) {}
-  ~tup() = default;
-};
+	template <typename... Ts>
+		struct tup : te_tup_metafunction<Ts...> {
+  			//tup(): te_tup_metafunction<Ts...>{}{}
+			tup() : te::te_tup_metafunction<Ts...>{}{
+				static_assert(te::eval_pipe_<te::ts_<Ts...>,te::all_of_<te::trait_<std::is_default_constructible>>>::value,"Type is not default constructible");
+			}
+  			tup(const Ts& ... ts) : te_tup_metafunction<Ts...>(ts...) {}
+  			template<typename ... Us>
+  				tup(Us &&... ts) : te_tup_metafunction<Ts...>(std::forward<Us>(ts)...) {}
+  			~tup() = default;
+		};
 
-template <typename... Ts>
-static inline te::tup<Ts...> make_tup(Ts &&... ts) {
-  return te::tup<Ts...>{std::forward<Ts>(ts)...};
-};
+	template <typename... Ts>
+		static inline te::tup<Ts...> make_tup(Ts &&... ts) {
+  			return te::tup<Ts...>{std::forward<Ts>(ts)...};
+		};
 
-template <unsigned int I, typename... Ts>
-auto get(te::tup<Ts...> &t) -> decltype(t.template get<I>()) {
-  return t.template get<I>();
-}
+	template <unsigned int I, typename... Ts>
+		auto get(te::tup<Ts...> &t) -> decltype(t.template get<I>()) {
+  			return t.template get<I>();
+		}
 
-template <class... Types>
-tup<Types &&...> forward_as_tup(Types &&... args) noexcept {
-  return te::tup<Types &&...>(std::forward<Types>(args)...);
-}
+	template <class... Types>
+		tup<Types &&...> forward_as_tup(Types &&... args) noexcept {
+  			return te::tup<Types &&...>(std::forward<Types>(args)...);
+		}
 
-template<typename ... Ts, std::size_t ... Is>
-te::eval_pipe_<te::input_<Ts...>,te::fork_<te::at_c<Is>...>,te::wrap_<tup>> tup_get(std::integer_sequence<std::size_t,Is...>,te::tup<Ts...>& tup)  
-{
-	return te::make_tup(std::move(te::get<Is>(tup))...);
-}
+	template<typename ... Ts, std::size_t ... Is>
+		te::eval_pipe_<te::input_<Ts...>,te::fork_<te::at_c<Is>...>,te::wrap_<tup>> tup_get(std::integer_sequence<std::size_t,Is...>,te::tup<Ts...>& tup)  
+		{
+			return te::make_tup(std::move(te::get<Is>(tup))...);
+		}
 
-template<typename ... Ts>
-using indexes = 
-te::eval_pipe_<te::input_<Ts...>, te::zip_index
+	template<typename ... Ts>
+		using indexes = 
+		te::eval_pipe_<te::input_<Ts...>, te::zip_index
 		,te::group_range_<te::second,te::size> 
 		,te::sort_<transform_<te::second,te::size>,te::greater_<>>
 		,te::transform_<te::first>
 		,te::wrap_std_integer_sequence_<std::size_t>
 		>;
 
-//TUP_SORT
-// Given a tuple, sort it by it's size, bigger first.
-//
-template<typename ... Ts>
-auto tup_sort(te::tup<Ts...>& tu) -> decltype(tup_get(indexes<Ts...>{},tu))
-{
-	
-	return tup_get(indexes<Ts...>{},tu);
+	//TUP_SORT
+	// Given a tuple, sort it by it's size, bigger first.
+	//
+	template<typename ... Ts>
+		auto tup_sort(te::tup<Ts...>& tu) -> decltype(tup_get(indexes<Ts...>{},tu))
+		{
 
-}
+			return tup_get(indexes<Ts...>{},tu);
 
-
+		}
 
 
-// TUP_CAT
-// Given multiple tup, concatenate them using the same expension trick than Eric
-// Niebler The trick is to get two std::integer_sequence which are the cartesian
-// cartesian of each indexes of the tups with their respective index in the
-// concatenation function. given tup< tup<A,B,C>, tup<D>, tup<>, tup<E,F> > //
-// Tup_of_Tups index_of_tup           = std::integer_sequence<int,0,0,0,1,3,3>
-// index inside each tup  = std::integer_sequence<int,0,1,2,0,0,1>
-//
-namespace detail {
-template <typename Ret,int... Is, int... Ks, typename... Ts, typename Tup_of_Tups>
-Ret tup_cat_impl(std::integer_sequence<int, Is...>,
-                            std::integer_sequence<int, Ks...>,
-                            Tup_of_Tups &&tpls) {
-  return te::make_tup(
-      // get<0>().get<0>(), get<0>().get<1>(), ...
-      tpls.template get<Is>().template get<Ks>()...);
-}
-};  // namespace detail
-template <typename... Tups, typename Ret = te::eval_pipe_<
-                                ts_<Tups...>, te::transform_<te::unwrap>,
-                                te::transform_<te::trait_<std::remove_reference>>, wrap_<te::tup>>>
-Ret tup_cat(Tups &&... tups) {
-  // This do the magic of getting the cartesian cartesian of each tup's types
-  // with the index inside
-  using zip_indexes = te::eval_pipe_<
-      te::ts_<Tups...>, te::transform_<te::unwrap, te::length, te::mkseq_<>>,
-      te::zip_index, transform_<te::cartesian_<te::listify>>
-      , te::flatten
-		  ,transform_<te::unwrap>
-		  , te::unzip>;
 
-  using tup_index =
-      te::eval_pipe_<zip_indexes, te::first, te::wrap_std_integer_sequence_<int>>;
-  using types_index =
-      te::eval_pipe_<zip_indexes, te::second, te::wrap_std_integer_sequence_<int>>;
-  return detail::tup_cat_impl<Ret>(
-      tup_index{},    // int_seq
-      types_index{},  // int_seq
-      te::forward_as_tup(std::forward<Tups>(tups)...));
-};
+
+	// TUP_CAT
+	// Given multiple tup, concatenate them using the same expension trick than Eric
+	// Niebler The trick is to get two std::integer_sequence which are the cartesian
+	// cartesian of each indexes of the tups with their respective index in the
+	// concatenation function. given tup< tup<A,B,C>, tup<D>, tup<>, tup<E,F> > //
+	// Tup_of_Tups index_of_tup           = std::integer_sequence<int,0,0,0,1,3,3>
+	// index inside each tup  = std::integer_sequence<int,0,1,2,0,0,1>
+	//
+	namespace detail {
+		template <typename Ret,int... Is, int... Ks, typename... Ts, typename Tup_of_Tups>
+			Ret tup_cat_impl(std::integer_sequence<int, Is...>,
+                    std::integer_sequence<int, Ks...>,
+                    Tup_of_Tups &&tpls) {
+  				return te::make_tup(
+      					// get<0>().get<0>(), get<0>().get<1>(), ...
+      					tpls.template get<Is>().template get<Ks>()...);
+			}
+	};  // namespace detail
+	template <typename... Tups, typename Ret = te::eval_pipe_<
+        ts_<Tups...>, te::transform_<te::unwrap>,
+        te::transform_<te::trait_<std::remove_reference>>, wrap_<te::tup>>>
+			Ret tup_cat(Tups &&... tups) {
+  				// This do the magic of getting the cartesian cartesian of each tup's types
+  				// with the index inside
+  				using zip_indexes = te::eval_pipe_<
+      				te::ts_<Tups...>, te::transform_<te::unwrap, te::length, te::mkseq_<>>,
+      			te::zip_index, transform_<te::cartesian_<te::listify>>
+      				, te::flatten
+		  			,transform_<te::unwrap>
+		  			, te::unzip>;
+
+  				using tup_index =
+      				te::eval_pipe_<zip_indexes, te::first, te::wrap_std_integer_sequence_<int>>;
+  				using types_index =
+      				te::eval_pipe_<zip_indexes, te::second, te::wrap_std_integer_sequence_<int>>;
+  				return detail::tup_cat_impl<Ret>(
+      					tup_index{},    // int_seq
+      					types_index{},  // int_seq
+      					te::forward_as_tup(std::forward<Tups>(tups)...));
+			};
 
 };  // namespace te
 

--- a/include/type_tup.hpp
+++ b/include/type_tup.hpp
@@ -22,6 +22,7 @@ namespace te {
 	template <typename... Zip_Indexes_Types>
 		struct tup_impl;
 
+	// TUP
 	template<typename ... Ts>
 		struct tup ;
 }
@@ -33,13 +34,8 @@ namespace std{
 }
 
 namespace te {
-	// TUP
-	/*template <typename... Ts>*/
-	//struct tup;
 
-	// IMPLEMENTATION
-
-	// TUP_INST
+	// TUP_ELEMENT
 	template <int I, typename T>
 		struct tup_element<te::i<I>, T> {
 	  		tup_element() : data{}{} 
@@ -93,14 +89,13 @@ namespace te {
   				}
 		};
 
-	// TUP
 
 	using sort_pred = te::pipe_<te::transform_<te::unwrap,te::second,te::size>,te::greater_<>>;
 	template <typename... Ts>
 		using te_tup_metafunction =
 		te::eval_pipe_<te::ts_<Ts...>, te::zip_index,te::transform_<wrap_<tup_element>>,/*te::sort_<sort_pred>,*/  te::wrap_<tup_impl>>;
 
-
+	// TUP
 	template <typename... Ts>
 		struct tup : te_tup_metafunction<Ts...> {
 			static constexpr std::size_t size = sizeof...(Ts);
@@ -108,7 +103,7 @@ namespace te {
 			~tup() = default;
 			tup(){
     			using dft_ctor = te::trait_<std::is_nothrow_default_constructible>;
-				static_assert(te::eval_pipe_<te::ts_<Ts...>,te::all_of_<dft_ctor>>::value,"Type is not default constructible");
+				static_assert(te::eval_pipe_<te::ts_<Ts...>,te::all_of_<dft_ctor>>::value,"All Types are not default constructible");
 			}
 			tup(const Ts& ... ts) : te_tup_metafunction<Ts...>(ts...) {}
 			template<typename ... Us>

--- a/include/type_tup.hpp
+++ b/include/type_tup.hpp
@@ -20,7 +20,7 @@ namespace te {
 
 	// TUP_INST
 	template <typename Index, typename Type>
-		struct tup_inst;
+		struct tup_element;
 
 	// TUP_IMPL
 	template <typename... Zip_Indexes_Types>
@@ -34,15 +34,15 @@ namespace te {
 
 	// TUP_INST
 	template <int I, typename T>
-		struct tup_inst<te::i<I>, T> {
-	  		tup_inst() : data{}{} 
-	  		tup_inst(const T& t) : data{t} {} // Ref
+		struct tup_element<te::i<I>, T> {
+	  		tup_element() : data{}{} 
+	  		tup_element(const T& t) : data{t} {} // Ref
 			template<typename U>
-	  			tup_inst(T &&t) : data{std::forward<T>(t)} {} // Move or copy
-  			~tup_inst() = default;
+	  			tup_element(T &&t) : data{std::forward<T>(t)} {} // Move or copy
+  			~tup_element() = default;
 
-			//tup_inst(const tup_inst<te::i<I>,T>& other) : data{other.data} {}
-			//tup_inst(te::tup_inst<te::i<I>,T>&& o) : data{std::forward<T>(o.data)}{}
+			//tup_element(const tup_element<te::i<I>,T>& other) : data{other.data} {}
+			//tup_element(te::tup_element<te::i<I>,T>&& o) : data{std::forward<T>(o.data)}{}
 			T& get()
 			{
 				return data;
@@ -54,19 +54,19 @@ namespace te {
 
 	// TUP_IMPL
 	template <typename... Is, typename... Ts>
-		struct tup_impl<tup_inst<Is, Ts>...> : tup_inst<Is, Ts>... {
-			tup_impl()  : tup_inst<Is,Ts>{}... {} 
-  			tup_impl(const Ts& ... ts) : tup_inst<Is, Ts>(ts)... {}
+		struct tup_impl<tup_element<Is, Ts>...> : tup_element<Is, Ts>... {
+			tup_impl()  : tup_element<Is,Ts>{}... {} 
+  			tup_impl(const Ts& ... ts) : tup_element<Is, Ts>(ts)... {}
   			template<typename ... Us>
-  				tup_impl(Us&&... ts) : tup_inst<Is, Ts>(std::forward<Us>(ts))... {}
+  				tup_impl(Us&&... ts) : tup_element<Is, Ts>(std::forward<Us>(ts))... {}
   			~tup_impl() = default;
 
-			tup_impl(const tup_impl<tup_inst<Is,Ts>...>& o) : tup_inst<Is, Ts>{tup_inst<Is,Ts>(o).get()}... {}
-			tup_impl(tup_impl<tup_inst<Is,Ts>...>&& o) : tup_inst<Is,Ts>{std::forward<Ts>(tup_inst<Is,Ts>(o).get())}...{}
+			tup_impl(const tup_impl<tup_element<Is,Ts>...>& o) : tup_element<Is, Ts>{tup_element<Is,Ts>(o).get()}... {}
+			tup_impl(tup_impl<tup_element<Is,Ts>...>&& o) : tup_element<Is,Ts>{std::forward<Ts>(tup_element<Is,Ts>(o).get())}...{}
 
   			template <unsigned int I>
   				auto get() -> te::eval_pipe_<te::ts_<te::ls_<Is,Ts>...>,te::filter_<te::unwrap,te::first,te::same_as_<te::i<I>>>,te::unwrap,te::second> & {
-					return te::eval_pipe_<te::ts_<te::ls_<Is,Ts>...>,te::filter_<te::unwrap,te::first,te::same_as_<i<I>>>,te::unwrap,te::wrap_<tup_inst>>::data;
+					return te::eval_pipe_<te::ts_<te::ls_<Is,Ts>...>,te::filter_<te::unwrap,te::first,te::same_as_<i<I>>>,te::unwrap,te::wrap_<tup_element>>::data;
   				}
 		};
 
@@ -74,7 +74,7 @@ namespace te {
 	using sort_pred = te::pipe_<te::transform_<te::unwrap,te::second,te::size>,te::greater_<>>;
 	template <typename... Ts>
 		using te_tup_metafunction =
-    	te::eval_pipe_<te::ts_<Ts...>, te::zip_index,te::transform_<wrap_<tup_inst>>,/*te::sort_<sort_pred>,*/  te::wrap_<tup_impl>>;
+    	te::eval_pipe_<te::ts_<Ts...>, te::zip_index,te::transform_<wrap_<tup_element>>,/*te::sort_<sort_pred>,*/  te::wrap_<tup_impl>>;
     template<typename ... Ts>
     	using tup_sequence = 
     	te::eval_pipe_<te::mkseq_c<sizeof...(Ts)>>;

--- a/include/type_tup.hpp
+++ b/include/type_tup.hpp
@@ -11,12 +11,9 @@
 
 #include "type_expr.hpp"
 
+// FORWARD DECLARATION
 namespace te {
 
-	template<typename T, typename ... Es>
-		using sfinae_t =  std::enable_if<eval_pipe_<Es...>::value,T>;
-
-	// FORWARD DECLARATION
 
 	// TUP_INST
 	template <typename Index, typename Type>
@@ -39,7 +36,7 @@ namespace te {
 namespace std{
 	template<typename > struct tuple_size;
 	template<typename ... Ts>
-	struct tuple_size<te::tup_impl<Ts...>> : public std::integral_constant<std::size_t,te::tup_impl<Ts...>::size>{};
+		struct tuple_size<te::tup_impl<Ts...>> : public std::integral_constant<std::size_t,te::tup_impl<Ts...>::size>{};
 }
 
 namespace te {
@@ -97,12 +94,12 @@ namespace te {
 
 	// TUP
 	using sort_pred = te::pipe_<te::transform_<te::unwrap,te::second,te::size>,te::greater_<>>;
-	
+
     template<typename ... Ts>
     	using tup_sequence = 
     	te::eval_pipe_<te::mkseq_c<sizeof...(Ts)>>;
     using dft_ctor = te::trait_<std::is_nothrow_default_constructible>;
-		//template <typename... Ts>
+	//template <typename... Ts>
 	//struct tup : te_tup_metafunction<Ts...> {
 	//tup() : te_tup_metafunction<Ts...>{}{ 
 	//static_assert(te::eval_pipe_<te::ts_<Ts...>,te::all_of_<dft_ctor>>::value,"Type is not default constructible");
@@ -181,25 +178,25 @@ namespace te {
 		using tup_cat_return = te::eval_pipe_<te::ts_<Ts...>,te::transform_<te::unwrap,te::transform_<te::unwrap,te::second>>,te::flatten,te::wrap_<te::tup>>;
 
 	template <typename... Tups>
-			tup_cat_return<Tups...> tup_cat(Tups &&... tups) {
-  				// This do the magic of getting the cartesian cartesian of each tup's types
-  				// with the index inside
-  				using zip_indexes = te::eval_pipe_<
-      				te::ts_<Tups...>, te::transform_<te::trait_<std::remove_reference>,te::trait_<std::tuple_size>, te::mkseq_<>>,
+		tup_cat_return<Tups...> tup_cat(Tups &&... tups) {
+  			// This do the magic of getting the cartesian cartesian of each tup's types
+  			// with the index inside
+  			using zip_indexes = te::eval_pipe_<
+      			te::ts_<Tups...>, te::transform_<te::trait_<std::remove_reference>,te::trait_<std::tuple_size>, te::mkseq_<>>,
       			te::zip_index, transform_<te::cartesian_<te::listify>>
       				, te::flatten
 		  			,transform_<te::unwrap>
 		  			, te::unzip>;
 
-  				using tup_index =
-      				te::eval_pipe_<zip_indexes, te::first, te::wrap_std_integer_sequence_<int>>;
-  				using types_index =
-      				te::eval_pipe_<zip_indexes, te::second, te::wrap_std_integer_sequence_<int>>;
-  				return detail::tup_cat_impl(
-      					tup_index{},    // int_seq
-      					types_index{},  // int_seq
-      					te::forward_as_tup(std::forward<Tups>(tups)...));
-			};
+  			using tup_index =
+      			te::eval_pipe_<zip_indexes, te::first, te::wrap_std_integer_sequence_<int>>;
+  			using types_index =
+      			te::eval_pipe_<zip_indexes, te::second, te::wrap_std_integer_sequence_<int>>;
+  			return detail::tup_cat_impl(
+      				tup_index{},    // int_seq
+      				types_index{},  // int_seq
+      				te::forward_as_tup(std::forward<Tups>(tups)...));
+		};
 
 };  // namespace te
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,10 +7,10 @@ option(TYPE_EXPR_TEST_MPL
 	ON)
 option(TYPE_EXPR_TEST_TUP
 	"Generate 'te::tup' tests` "
-	OFF)
+	ON)
 option(TYPE_EXPR_TEST_VAR
 	"Generate 'te::var' tests` "
-	OFF)
+	ON)
 
 if (BUILD_TESTING AND TYPE_EXPR_TEST  )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,17 +2,32 @@
 cmake_minimum_required(VERSION 3.0) 
 message(STATUS "Type_expr's test cmake configuration ")
 
+option(TYPE_EXPR_TEST_MPL
+	"Generate 'te' tests` "
+	ON)
+option(TYPE_EXPR_TEST_TUP
+	"Generate 'te::tup' tests` "
+	OFF)
+option(TYPE_EXPR_TEST_VAR
+	"Generate 'te::var' tests` "
+	OFF)
+
 if (BUILD_TESTING AND TYPE_EXPR_TEST  )
+
+	if(TYPE_EXPR_TEST_MPL)
         add_executable(type_expr_test expr_test.cpp)
         target_link_libraries(type_expr_test type_expr)
         add_test(Test_of_Type_Expr type_expr_test) 
-
+    endif()
+	if(TYPE_EXPR_TEST_TUP)
         add_executable(test_tup tup_test.cpp)
         target_link_libraries(test_tup type_expr)
         add_test(Test_of_Tup test_tup)
-
+	endif()
+	if(TYPE_EXPR_TEST_VAR)
         add_executable(test_var var_test.cpp)
         target_link_libraries(test_var type_expr)
         add_test(Test_of_Var test_var)
+    endif()
 
 endif()

--- a/test/tup_test.cpp
+++ b/test/tup_test.cpp
@@ -5,55 +5,75 @@
 
 #include <assert.h>
 
+#include <tuple>
 #include <string>
 #include <memory>
 
-#include <type_traits>
 
-#include "type_expr.hpp"
-#include "type_tup.hpp"
+#include <type_expr.hpp>
+#include <type_tup.hpp>
 
-using nocopy = std::unique_ptr<int>;
+	static_assert(
+			sizeof(te::tup<short,int,char>) < sizeof(std::tuple<short,int,char>)
+			,"");
+	//tup's types are internally sorted from biggest to smallest size to avoid
+	// padding issues while still allowing typical get<int N>() access 
 
 
-// TYPE_TUP Test
-int main() {
-	int i = 42;
-	te::tup<int> t0{}; // Default Ctor
+	// TYPE_TUP Test
+int main() 
+{
+	using nocopy = std::unique_ptr<int>;
 
-	te::tup<int> t1{42};
-	te::tup<int> t2{i};
-	te::tup<int> t3{std::move(i)};
-	assert(t1.get<0>() == 42 && t2.get<0>() == 42 && t3.get<0>() == 42);
-
-	int j = 42, k = 43;
-	te::tup<int&> tr1{j};
-
-	te::tup<int,int> tii {1,2};
-	assert(tii.get<0>() == 1 && tii.get<1>() == 2);
-
-	int l = 22,  m = 23;
-	te::tup<int&,int> trii{l,9};
-	te::tup<int,int> tii2{std::move(m),9};
-	assert(trii.get<0>() == 22 && trii.get<1>() == 9);
-	assert(tii2.get<0>() == 23 && tii2.get<1>() == 9);
-
-	te::tup<te::tup<int>&, te::tup<int>> titi{t1, {9}};
-	assert(titi.get<0>().get<0>() == 42 && titi.get<1>().get<0>() == 9);
-
-	auto tup_assignment = te::tup<int>{1}; 
-	assert(tup_assignment.get<0>() == 1);
-
-	te::tup<std::string>{"Hello"};
-	te::tup<std::string,int> str_name("Hello",42);
-	assert(str_name.get<1>() == 42 && str_name.get<0>() == "Hello");
-
-	auto tt3 = te::make_tup(4, 5, 6);
-	assert(tt3.get<2>() == 6);
-
-	nocopy nc = std::make_unique<int>(42);
-	//te::tup<nocopy> tnc (std::move(nc));
-
+	{
+		te::tup<int> t0{}; // Default Ctor
+	}
+	{
+		int i = 42;
+		te::tup<int> t1{42};
+		te::tup<int> t2{i};
+		te::tup<int> t3{std::move(i)};
+		assert(t1.get<0>() == 42 && t2.get<0>() == 42 && t3.get<0>() == 42);
+	}
+	{
+		int j = 42, k = 43;
+		te::tup<int&> tr1{j};
+		te::tup<int,int> tii {1,2};
+		assert(tii.get<0>() == 1 && tii.get<1>() == 2);
+	}
+	{
+		int l = 22,  m = 23;
+		te::tup<int&,int> trii{l,9};
+		te::tup<int,int> tii2{std::move(m),9};
+		assert(trii.get<0>() == 22 && trii.get<1>() == 9);
+		assert(tii2.get<0>() == 23 && tii2.get<1>() == 9);
+	}
+	{
+		te::tup<int> t1{42};
+		te::tup<te::tup<int>&, te::tup<int>> titi{t1, {9}};
+		assert(titi.get<0>().get<0>() == 42 && titi.get<1>().get<0>() == 9);
+	}
+	{
+		auto tup_assignment = te::tup<int>{1}, tup_to_move = te::tup<int>{42}; 
+		auto tup_moved = std::move(tup_to_move);
+		assert(tup_assignment.get<0>() == 1 && tup_moved.get<0>() == 42);
+	}
+	{
+		te::tup<std::string>{"Hello"};
+		te::tup<std::string,int> str_int("Hello",42);
+		assert(str_int.get<1>() == 42 && str_int.get<0>() == "Hello");
+		te::tup<int,std::string> int_str{42,"Hello"};
+		assert(int_str.get<0>() == 42 && int_str.get<1>() == "Hello");
+	}
+	{
+		auto tt3 = te::make_tup(4, 5, 6);
+		assert(tt3.get<2>() == 6);
+	}
+	{
+		nocopy nc {};
+		te::tup<nocopy> tnc (std::move(nc));
+		te::tup<nocopy> tup_nocopy{ std::move(tnc)};
+	}
   	////auto tt6 = tup_cat(tt1, tt2, tt3);
   	////assert(tt6.get<4>() == 5);
 

--- a/test/tup_test.cpp
+++ b/test/tup_test.cpp
@@ -88,9 +88,22 @@ int main()
 		te::tup<nocopy> tnc (std::move(nc));
 		te::tup<nocopy> tup_nocopy{ std::move(tnc)};
 	}
-  	////auto tt6 = tup_cat(tt1, tt2, tt3);
-  	////assert(tt6.get<4>() == 5);
-
+	{
+		int i = 42;
+		auto tfwd = te::forward_as_tup(i,54);
+	}
+	{
+		te::tup<int> t1{42};
+		te::tup<int,float> t2{23,100.0f};
+		te::tup<std::string,int > t3{"Hello",100};
+		auto tt5 = te::tup_cat(t1, t2, t3);
+		assert(	tt5.get<0>() == 42 &&
+				tt5.get<1>() == 23 &&
+				tt5.get<2>() == 100.0f &&
+				tt5.get<3>() == "Hello" &&
+				tt5.get<4>() == 100
+				);
+	}
   	//auto ttt = te::make_tup(tt1,tt2);
 
   	//auto ttsorted = tup_sort(tt6);

--- a/test/tup_test.cpp
+++ b/test/tup_test.cpp
@@ -24,6 +24,7 @@
 		int i;
 		char c;
 	};
+
 struct good_padding{
 	int i;
 	short s;

--- a/test/tup_test.cpp
+++ b/test/tup_test.cpp
@@ -104,9 +104,16 @@ int main()
 				tt5.get<4>() == 100
 			  );
 	}
-  	//auto ttt = te::make_tup(tt1,tt2);
-
-  	//auto ttsorted = tup_sort(tt6);
-  	// TYPE_TUP
+	{
+		te::tup<int,std::string,int,std::string> isis{1,"Hello",3,"World"};
+		bool test = 
+			isis.get<int>() == 1 &&
+			isis.get<int,1>() == 3 &&
+			isis.get<std::string>() == "Hello" &&
+			isis.get<std::string,1>() == "World"; 
+		assert(test == true);
+		isis.get<int>() = 0;
+		assert(isis.get<int>() == 0);
+	}
   	return 0;
 }

--- a/test/tup_test.cpp
+++ b/test/tup_test.cpp
@@ -5,23 +5,52 @@
 
 #include <assert.h>
 
+#include <string>
+
 #include <type_traits>
 
 #include "type_expr.hpp"
 #include "type_tup.hpp"
 
+
+
+
 // TYPE_TUP Test
 int main() {
-  te::tup<int> tt1{1};
-  te::tup<int, float> tt2{-2, 3.0f};
-  tt2.get<0>() = 2;
-  assert(tt2.get<0>() == 2);
-  auto tt3 = te::make_tup(4, 5, 6);
-  assert(tt3.get<2>() == 6);
-  auto tt6 = tup_cat(tt1, tt2, tt3);
-  assert(tt6.get<4>() == 5);
+	int i = 42;
+	//te::tup<int> t0{};
+	te::tup<int> t1{42};
+	te::tup<int> t2{i};
+	te::tup<int> t3{std::move(i)};
+	assert(t1.get<0>() == 42 && t2.get<0>() == 42 && t3.get<0>() == 42);
 
-  auto ttsorted = tup_sort(tt6);
+	int j = 42, k = 43;
+	te::tup<int&> tr1{j};
+
+	te::tup<int,int> tii {1,2};
+	assert(tii.get<0>() == 1 && tii.get<1>() == 2);
+
+	int l = 22,  m = 23;
+	te::tup<int&,int> trii{l,9};
+	te::tup<int,int> tii2{std::move(m),9};
+	assert(trii.get<0>() == 22 && trii.get<1>() == 9);
+	assert(tii2.get<0>() == 23 && tii2.get<1>() == 9);
+
+	te::tup<te::tup<int>&, te::tup<int>> titi{t1, {9}};
+	assert(titi.get<0>().get<0>() == 42 && titi.get<1>().get<0>() == 9);
+  //tt2.get<0>() = 2;
+  //assert(tt2.get<0>() == 2);
+
+
+
+  //auto tt3 = te::make_tup(4, 5, 6);
+  //assert(tt3.get<2>() == 6);
+  ////auto tt6 = tup_cat(tt1, tt2, tt3);
+  ////assert(tt6.get<4>() == 5);
+
+  //auto ttt = te::make_tup(tt1,tt2);
+
+  //auto ttsorted = tup_sort(tt6);
   // TYPE_TUP
   return 0;
 }

--- a/test/tup_test.cpp
+++ b/test/tup_test.cpp
@@ -6,13 +6,14 @@
 #include <assert.h>
 
 #include <string>
+#include <memory>
 
 #include <type_traits>
 
 #include "type_expr.hpp"
 #include "type_tup.hpp"
 
-
+using nocopy = std::unique_ptr<int>;
 
 
 // TYPE_TUP Test
@@ -44,10 +45,15 @@ int main() {
 	assert(tup_assignment.get<0>() == 1);
 
 	te::tup<std::string>{"Hello"};
-	te::tup<std::string,int>("Hello",8);
+	te::tup<std::string,int> str_name("Hello",42);
+	assert(str_name.get<1>() == 42 && str_name.get<0>() == "Hello");
 
 	auto tt3 = te::make_tup(4, 5, 6);
 	assert(tt3.get<2>() == 6);
+
+	nocopy nc = std::make_unique<int>(42);
+	//te::tup<nocopy> tnc (std::move(nc));
+
   	////auto tt6 = tup_cat(tt1, tt2, tt3);
   	////assert(tt6.get<4>() == 5);
 

--- a/test/tup_test.cpp
+++ b/test/tup_test.cpp
@@ -18,6 +18,20 @@
 			,"");
 	//tup's types are internally sorted from biggest to smallest size to avoid
 	// padding issues while still allowing typical get<int N>() access 
+	
+	struct bad_padding {
+		short s;
+		int i;
+		char c;
+	};
+	struct good_padding{
+		int i;
+		short s;
+		char c;
+	};
+	static_assert(sizeof(good_padding) < sizeof(bad_padding),"");
+	static_assert(sizeof(good_padding) == sizeof(te::tup<short,int,char>),"");
+	
 
 
 	// TYPE_TUP Test

--- a/test/tup_test.cpp
+++ b/test/tup_test.cpp
@@ -38,19 +38,19 @@ int main() {
 
 	te::tup<te::tup<int>&, te::tup<int>> titi{t1, {9}};
 	assert(titi.get<0>().get<0>() == 42 && titi.get<1>().get<0>() == 9);
-  //tt2.get<0>() = 2;
-  //assert(tt2.get<0>() == 2);
+  	//tt2.get<0>() = 2;
+  	//assert(tt2.get<0>() == 2);
 
 
 
-  //auto tt3 = te::make_tup(4, 5, 6);
-  //assert(tt3.get<2>() == 6);
-  ////auto tt6 = tup_cat(tt1, tt2, tt3);
-  ////assert(tt6.get<4>() == 5);
+  	//auto tt3 = te::make_tup(4, 5, 6);
+  	//assert(tt3.get<2>() == 6);
+  	////auto tt6 = tup_cat(tt1, tt2, tt3);
+  	////assert(tt6.get<4>() == 5);
 
-  //auto ttt = te::make_tup(tt1,tt2);
+  	//auto ttt = te::make_tup(tt1,tt2);
 
-  //auto ttsorted = tup_sort(tt6);
-  // TYPE_TUP
-  return 0;
+  	//auto ttsorted = tup_sort(tt6);
+  	// TYPE_TUP
+  	return 0;
 }

--- a/test/tup_test.cpp
+++ b/test/tup_test.cpp
@@ -18,7 +18,8 @@
 // TYPE_TUP Test
 int main() {
 	int i = 42;
-	//te::tup<int> t0{};
+	te::tup<int> t0{}; // Default Ctor
+
 	te::tup<int> t1{42};
 	te::tup<int> t2{i};
 	te::tup<int> t3{std::move(i)};
@@ -38,13 +39,15 @@ int main() {
 
 	te::tup<te::tup<int>&, te::tup<int>> titi{t1, {9}};
 	assert(titi.get<0>().get<0>() == 42 && titi.get<1>().get<0>() == 9);
-  	//tt2.get<0>() = 2;
-  	//assert(tt2.get<0>() == 2);
 
+	auto tup_assignment = te::tup<int>{1}; 
+	assert(tup_assignment.get<0>() == 1);
 
+	te::tup<std::string>{"Hello"};
+	te::tup<std::string,int>("Hello",8);
 
-  	//auto tt3 = te::make_tup(4, 5, 6);
-  	//assert(tt3.get<2>() == 6);
+	auto tt3 = te::make_tup(4, 5, 6);
+	assert(tt3.get<2>() == 6);
   	////auto tt6 = tup_cat(tt1, tt2, tt3);
   	////assert(tt6.get<4>() == 5);
 

--- a/test/tup_test.cpp
+++ b/test/tup_test.cpp
@@ -18,23 +18,23 @@
 			,"");
 	//tup's types are internally sorted from biggest to smallest size to avoid
 	// padding issues while still allowing typical get<int N>() access 
-	
+
 	struct bad_padding {
 		short s;
 		int i;
 		char c;
 	};
-	struct good_padding{
-		int i;
-		short s;
-		char c;
-	};
-	static_assert(sizeof(good_padding) < sizeof(bad_padding),"");
-	static_assert(sizeof(good_padding) == sizeof(te::tup<short,int,char>),"");
-	
+struct good_padding{
+	int i;
+	short s;
+	char c;
+};
+static_assert(sizeof(good_padding) < sizeof(bad_padding),"");
+static_assert(sizeof(good_padding) == sizeof(te::tup<short,int,char>),"");
 
 
-	// TYPE_TUP Test
+
+// TYPE_TUP Test
 int main() 
 {
 	using nocopy = std::unique_ptr<int>;
@@ -102,7 +102,7 @@ int main()
 				tt5.get<2>() == 100.0f &&
 				tt5.get<3>() == "Hello" &&
 				tt5.get<4>() == 100
-				);
+			  );
 	}
   	//auto ttt = te::make_tup(tt1,tt2);
 


### PR DESCRIPTION
**te::tup**
After some rework, te::tup is now a decent tuple, with the twist of sorting the types by greatest size first, avoiding some alignment issues, without the users having to do anything.

**te mpl**
te::sort_<BP...> is now fixed as described in #11, which open a lot of new exciting fix to come.

te::keep_if_ introduced as an alternative to filter_

**CMake**
CMake test options added 

